### PR TITLE
Add support for authentication using certificates

### DIFF
--- a/cmreslogging/handlers.py
+++ b/cmreslogging/handlers.py
@@ -41,11 +41,13 @@ class CMRESHandler(logging.Handler):
          - No authentication
          - Basic authentication
          - Kerberos or SSO authentication (on windows and linux)
+         - Authentication using certificate
         """
         NO_AUTH = 0
         BASIC_AUTH = 1
         KERBEROS_AUTH = 2
         AWS_SIGNED_AUTH = 3
+        CERT_AUTH = 4
 
     class IndexNameFrequency(Enum):
         """ Index type supported
@@ -78,6 +80,8 @@ class CMRESHandler(logging.Handler):
     __DEFAULT_ES_DOC_TYPE = 'python_log'
     __DEFAULT_RAISE_ON_EXCEPTION = False
     __DEFAULT_TIMESTAMP_FIELD_NAME = "timestamp"
+    __DEFAULT_ES_RETRY_ON_TIMEOUT = False
+    __DEFAULT_ES_TIMEOUT = 10
 
     __LOGGING_FILTER_FIELDS = ['msecs',
                                'relativeCreated',
@@ -142,8 +146,10 @@ class CMRESHandler(logging.Handler):
                  es_additional_fields=__DEFAULT_ADDITIONAL_FIELDS,
                  raise_on_indexing_exceptions=__DEFAULT_RAISE_ON_EXCEPTION,
                  default_timestamp_field_name=__DEFAULT_TIMESTAMP_FIELD_NAME,
-                 es_retry_on_timeout=False,
-                 es_timeout=10):
+                 es_retry_on_timeout=__DEFAULT_ES_RETRY_ON_TIMEOUT,
+                 es_timeout=__DEFAULT_ES_TIMEOUT,
+                 client_cert=None,
+                 ca_certs=None):
         """ Handler constructor
 
         :param hosts: The list of hosts that elasticsearch clients will connect. The list can be provided
@@ -181,6 +187,8 @@ class CMRESHandler(logging.Handler):
                     sending logs after timeout.
         :param es_timeout: An integer value, in seconds, passed to Elasticsearch object. Specifies client-side
                     timeout when performing bulk_send.
+        :param client_cert: String (path to a cert) or tuple (in the case of cert + key). Passed to requests session.
+        :param ca_certs: String, path to CA certificate (or a bundle).
         :return: A ready to be used CMRESHandler.
         """
         logging.Handler.__init__(self)
@@ -205,6 +213,8 @@ class CMRESHandler(logging.Handler):
         self.default_timestamp_field_name = default_timestamp_field_name
         self.es_retry_on_timeout = es_retry_on_timeout
         self.es_timeout = es_timeout
+        self.client_cert = client_cert
+        self.ca_certs = ca_certs
 
         self._client = None
         self._buffer = []
@@ -220,7 +230,9 @@ class CMRESHandler(logging.Handler):
             self._timer.start()
 
     def __get_es_client(self):
-        if self.auth_type == CMRESHandler.AuthType.NO_AUTH:
+        if self.auth_type in [CMRESHandler.AuthType.NO_AUTH, CMRESHandler.AuthType.CERT_AUTH]:
+            if self.auth_type == CMRESHandler.AuthType.CERT_AUTH and self.client_cert is None:
+                raise ValueError("client_cert parameter is required for CERT_AUTH")
             if self._client is None:
                 self._client = Elasticsearch(hosts=self.hosts,
                                              use_ssl=self.use_ssl,
@@ -228,7 +240,9 @@ class CMRESHandler(logging.Handler):
                                              connection_class=RequestsHttpConnection,
                                              serializer=self.serializer,
                                              retry_on_timeout=self.es_retry_on_timeout,
-                                             timeout=self.es_timeout)
+                                             timeout=self.es_timeout,
+                                             client_cert=self.client_cert,
+                                             ca_certs=self.ca_certs)
             return self._client
 
         if self.auth_type == CMRESHandler.AuthType.BASIC_AUTH:
@@ -240,7 +254,9 @@ class CMRESHandler(logging.Handler):
                                      connection_class=RequestsHttpConnection,
                                      serializer=self.serializer,
                                      retry_on_timeout=self.es_retry_on_timeout,
-                                     timeout=self.es_timeout)
+                                     timeout=self.es_timeout,
+                                     client_cert=self.client_cert,
+                                     ca_certs=self.ca_certs)
             return self._client
 
         if self.auth_type == CMRESHandler.AuthType.KERBEROS_AUTH:
@@ -254,7 +270,9 @@ class CMRESHandler(logging.Handler):
                                  http_auth=HTTPKerberosAuth(mutual_authentication=DISABLED),
                                  serializer=self.serializer,
                                  retry_on_timeout=self.es_retry_on_timeout,
-                                 timeout=self.es_timeout)
+                                 timeout=self.es_timeout,
+                                 client_cert=self.client_cert,
+                                 ca_certs=self.ca_certs)
 
         if self.auth_type == CMRESHandler.AuthType.AWS_SIGNED_AUTH:
             if not AWS4AUTH_SUPPORTED:
@@ -269,8 +287,9 @@ class CMRESHandler(logging.Handler):
                     connection_class=RequestsHttpConnection,
                     serializer=self.serializer,
                     retry_on_timeout=self.es_retry_on_timeout,
-                    timeout=self.es_timeout
-                )
+                    timeout=self.es_timeout,
+                    client_cert=self.client_cert,
+                    ca_certs=self.ca_certs)
             return self._client
 
         raise ValueError("Authentication method not supported")


### PR DESCRIPTION
client_cert and ca_certs are new parameters of CMRESHandler.
CERT_AUTH is an alais for NO_AUTH to support both cert + HTTP auth
for other authentication methods.